### PR TITLE
Allow newer version of aeson

### DIFF
--- a/quickbooks.cabal
+++ b/quickbooks.cabal
@@ -66,7 +66,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall
   build-depends:         base               >= 4.7   && < 4.8
-                       , aeson              >= 0.7   && <= 0.8
+                       , aeson              >= 0.7   && < 0.9
                        , authenticate-oauth == 1.5.*
                        , bytestring         == 0.10.*
                        , http-client        == 0.4.*


### PR DESCRIPTION
Right now, aeson is restricted to <= 0.8, which is incompatible with the version resolved for cobalt-kiosk-data-template. If we allow < 0.9 instead, everything works fine.
