### PR TITLE
[issue_14] Expose functions which take config.

### DIFF
--- a/quickbooks.cabal
+++ b/quickbooks.cabal
@@ -1,5 +1,5 @@
 name:                quickbooks
-version:             0.2.1
+version:             0.2.2.0
 synopsis:            QuickBooks API binding.
 -- description:
 license:             BSD3


### PR DESCRIPTION
This will give us the ability to configure it explicitly. Yet the auth functions should probably take all of there params explicitly outside of an `APIConfig` since when these functions are called data for a full config will likely be unavailable. 