### PR TITLE
[issue_14] Segregate application configuration.

### DIFF
--- a/quickbooks.cabal
+++ b/quickbooks.cabal
@@ -1,5 +1,5 @@
 name:                quickbooks
-version:             0.2.2.0
+version:             0.3.0.0
 synopsis:            QuickBooks API binding.
 -- description:
 license:             BSD3

--- a/src/QuickBooks.hs
+++ b/src/QuickBooks.hs
@@ -39,6 +39,7 @@ module QuickBooks
   , EmailAddress
   , emailAddress
   , sendInvoice
+  , sendInvoice'
     -- * Name list entities
     -- ** Customer
   , queryCustomer
@@ -270,7 +271,7 @@ deleteInvoice' apiConfig appConfig tok iId = queryQuickBooks' apiConfig appConfi
 -- >>> :{
 -- do eitherSendInvoice <- sendInvoice oAuthToken cInvoiceId testEmail
 --    case eitherSendInvoice of
---      Left e -> putStrLn e
+--      Left e  -> putStrLn e
 --      Right _ -> putStrLn "I sent an invoice!"
 -- :}
 -- I sent an invoice!
@@ -281,6 +282,15 @@ deleteInvoice' apiConfig appConfig tok iId = queryQuickBooks' apiConfig appConfi
 
 sendInvoice ::  OAuthToken -> InvoiceId -> EmailAddress -> IO (Either String (QuickBooksResponse Invoice))
 sendInvoice tok invId = queryQuickBooks tok . SendInvoice invId
+
+sendInvoice' :: APIConfig
+             -> AppConfig
+             -> OAuthToken
+             -> InvoiceId
+             -> EmailAddress
+             -> IO (Either String (QuickBooksResponse Invoice))
+sendInvoice' apiConfig appConfig tok invId  =
+  queryQuickBooks' apiConfig appConfig tok . SendInvoice invId
 
 -- | Get temporary tokens to request permission.
 --

--- a/src/QuickBooks/Customer.hs
+++ b/src/QuickBooks/Customer.hs
@@ -37,6 +37,7 @@ import Network.HTTP.Types.Header (hAccept)
 
 queryCustomerRequest
   :: ( ?apiConfig :: APIConfig
+     , ?appConfig :: AppConfig
      , ?manager   :: Manager
      , ?logger    :: Logger
      )

--- a/src/QuickBooks/Invoice.hs
+++ b/src/QuickBooks/Invoice.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
-
+{-# LANGUAGE RankNTypes        #-}
 ------------------------------------------------------------------------------
 -- |
 -- Module      : QuickBooks.Requests
@@ -38,28 +38,33 @@ import Network.HTTP.Types.Header (hAccept,hContentType)
 import QuickBooks.Authentication
 import QuickBooks.Logging (logAPICall, Logger)
 import QuickBooks.Types (APIConfig(..)
+                        ,AppConfig(..) 
                         ,Invoice
                         ,InvoiceId(..)
                         ,QuickBooksResponse
                         ,SyncToken(..)
                         ,DeletedInvoice(..)
-                        , OAuthToken)
+                        ,OAuthToken)
 
 import Text.Email.Validate (EmailAddress, toByteString)
 
 
+type Configured a = ( ?apiConfig :: APIConfig
+                    , ?appConfig :: AppConfig
+                    , ?manager   :: Manager
+                    , ?logger    :: Logger
+                    ) => a
+
 -- | Create an invoice.
-createInvoiceRequest :: ( ?apiConfig :: APIConfig
-                        , ?manager   :: Manager
-                        , ?logger    :: Logger
-                        ) => OAuthToken
-                          -> Invoice                         
-                          -> IO (Either String (QuickBooksResponse Invoice))
+createInvoiceRequest :: Configured (OAuthToken
+                                    -> Invoice                         
+                                    -> IO (Either String (QuickBooksResponse Invoice)))
 createInvoiceRequest tok = postInvoice tok
   
 
 -- | Update an invoice.
 updateInvoiceRequest :: ( ?apiConfig :: APIConfig
+                        , ?appConfig :: AppConfig
                         , ?manager :: Manager
                         , ?logger    :: Logger
                         ) => OAuthToken
@@ -69,6 +74,7 @@ updateInvoiceRequest tok = postInvoice tok
 
 -- | Read an invoice.
 readInvoiceRequest :: ( ?apiConfig :: APIConfig
+                      , ?appConfig :: AppConfig
                       , ?manager   :: Manager
                       , ?logger    :: Logger
                       ) => OAuthToken
@@ -85,6 +91,7 @@ readInvoiceRequest tok iId = do
 
 -- | Delete an invoice.
 deleteInvoiceRequest :: ( ?apiConfig :: APIConfig
+                        , ?appConfig :: AppConfig
                         , ?manager   :: Manager
                         , ?logger    :: Logger
                         ) => OAuthToken
@@ -110,6 +117,7 @@ deleteInvoiceRequest tok iId syncToken = do
 
 -- | email and invoice
 sendInvoiceRequest :: ( ?apiConfig :: APIConfig
+                      , ?appConfig :: AppConfig
                       , ?manager   :: Manager
                       , ?logger    :: Logger
                       ) => OAuthToken
@@ -132,6 +140,7 @@ invoiceURITemplate APIConfig{..} = [i|https://#{hostname}/v3/company/#{companyId
 
 
 postInvoice :: ( ?apiConfig :: APIConfig
+               , ?appConfig :: AppConfig
                , ?manager   :: Manager
                , ?logger    :: Logger
                ) => OAuthToken

--- a/src/QuickBooks/Item.hs
+++ b/src/QuickBooks/Item.hs
@@ -37,6 +37,7 @@ import Network.HTTP.Types.Header (hAccept)
 
 queryItemRequest
   :: ( ?apiConfig :: APIConfig
+     , ?appConfig :: AppConfig
      , ?manager   :: Manager
      , ?logger    :: Logger
      )

--- a/src/QuickBooks/Logging.hs
+++ b/src/QuickBooks/Logging.hs
@@ -3,19 +3,24 @@
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
 
-module QuickBooks.Logging (logAPICall, Logger, apiLogger, getLogger) where
+module QuickBooks.Logging ( logAPICall
+                          , logAPICall'
+                          , Logger
+                          , apiLogger
+                          , getLogger
+                          ) where
 
-import Control.Monad (when)
+import Control.Monad             (when)
 import Data.Char                 (toLower)
 import Data.IORef
-import Data.Monoid ((<>))
-import Data.String (fromString)
+import Data.Monoid               ((<>))
+import Data.String               (fromString)
 import Data.String.Interpolate   (i)
 import Data.Thyme
-import Network.HTTP.Client       ( Request(..),RequestBody(..),getUri)
+import Network.HTTP.Client       (Request(..),RequestBody(..),getUri)
 import System.IO.Unsafe
 import System.Locale 
-import System.Log.FastLogger (LoggerSet, LogStr, pushLogStr, flushLogStr, newStdoutLoggerSet)
+import System.Log.FastLogger     (LoggerSet, LogStr, pushLogStr, flushLogStr, newStdoutLoggerSet)
 import qualified Data.ByteString.Char8 as BS
 
 import QuickBooks.Types (APIConfig(..))
@@ -33,13 +38,14 @@ logAPICall :: ( ?logger :: Logger
               ) => Request -> IO ()
 logAPICall req =
   let isLoggingEnabled = BS.map toLower (loggingEnabled ?apiConfig)
-      in when (isLoggingEnabled == "true") logAPICall'
-  where
-    logAPICall' = do 
-      now <- getCurrentTime
-      let formattedTime = fromString $ formatTime defaultTimeLocale rfc822DateFormat now
-      pushLogStr ?logger (requestLogLine req formattedTime)
-      flushLogStr ?logger
+      in when (isLoggingEnabled == "true") $ logAPICall' req
+
+logAPICall' :: (?logger :: Logger) => Request -> IO ()
+logAPICall' req = do 
+  now <- getCurrentTime
+  let formattedTime = fromString $ formatTime defaultTimeLocale rfc822DateFormat now
+  pushLogStr ?logger (requestLogLine req formattedTime)
+  flushLogStr ?logger
 
 requestLogLine :: Request -> LogStr -> LogStr
 requestLogLine req formattedTime =

--- a/src/QuickBooks/Types.hs
+++ b/src/QuickBooks/Types.hs
@@ -38,10 +38,15 @@ type CallbackURL = String
 newtype OAuthVerifier = OAuthVerifier { unOAuthVerifier :: ByteString }
   deriving (Show, Eq)
 
+-- | QuickBooks Application Keys
+
+data AppConfig = AppConfig
+  { consumerToken  :: !ByteString
+  , consumerSecret :: !ByteString
+  } deriving (Show, Eq)
+
 data APIConfig = APIConfig
   { companyId      :: !ByteString
-  , consumerToken  :: !ByteString
-  , consumerSecret :: !ByteString
   , oauthToken     :: !ByteString
   , oauthSecret    :: !ByteString
   , hostname       :: !ByteString
@@ -90,16 +95,19 @@ instance FromJSON (QuickBooksResponse [Item]) where
   parseJSON _          = fail "Could not parse item response from QuickBooks"
 
 type QuickBooksQuery a = QuickBooksRequest (QuickBooksResponse a)
+type QuickBooksOAuthQuery a = QuickBooksOAuthRequest (QuickBooksResponse a) 
+
+data QuickBooksOAuthRequest a where
+  GetTempOAuthCredentials :: CallbackURL   -> QuickBooksOAuthQuery OAuthToken
+  GetAccessTokens         :: OAuthVerifier -> QuickBooksOAuthQuery OAuthToken
+  DisconnectQuickBooks    :: QuickBooksOAuthQuery ()
 
 data QuickBooksRequest a where
-  GetTempOAuthCredentials :: CallbackURL -> QuickBooksQuery OAuthToken
-  GetAccessTokens         :: OAuthVerifier -> QuickBooksQuery OAuthToken
   CreateInvoice           :: Invoice     -> QuickBooksQuery Invoice
   ReadInvoice             :: InvoiceId   -> QuickBooksQuery Invoice
   UpdateInvoice           :: Invoice     -> QuickBooksQuery Invoice
   DeleteInvoice           :: InvoiceId   -> SyncToken -> QuickBooksQuery DeletedInvoice
   SendInvoice             :: InvoiceId   -> E.EmailAddress -> QuickBooksQuery Invoice
-  DisconnectQuickBooks    :: QuickBooksQuery ()
 
   QueryCustomer           :: Text -> QuickBooksQuery [Customer]
   QueryItem               :: Text -> QuickBooksQuery [Item]


### PR DESCRIPTION
Separate the application configuration from the API configuration. This
is valuable for web application where clients require their own api
configuration while the web application itself require a QuickBooks
application configuration.