### PR TITLE
Support for empty item queries

### DIFF
--- a/src/QuickBooks/Types.hs
+++ b/src/QuickBooks/Types.hs
@@ -147,7 +147,7 @@ instance FromJSON (QuickBooksResponse [Item]) where
     where
       parseQueryResponse obj = do
         qResponse <- obj .: "QueryResponse"
-        parseItems qResponse
+        parseItems qResponse <|> (return (QuickBooksItemResponse []))
       parseItems obj = QuickBooksItemResponse <$> obj .: "Item"
       parseSingleItem obj = do
         i <- obj .: "Item"


### PR DESCRIPTION
Item queries that have no results will now return QuickBooksItemResponse [] instead of an error