### PR TITLE
Changing text fields to qbtext

### DIFF
--- a/quickbooks.cabal
+++ b/quickbooks.cabal
@@ -65,6 +65,7 @@ library
                        QuickBooks.Invoice
                        QuickBooks.Item
                        QuickBooks.Logging
+                       QuickBooks.QBText
                        QuickBooks.Types
 
 
@@ -82,6 +83,7 @@ library
                        , http-types
                        , http-client-tls
                        , interpolate
+                       , MissingH
                        , network-uri
                        , text
                        , fast-logger
@@ -105,6 +107,7 @@ test-suite api-tests
                   , QuickBooks.Invoice
                   , QuickBooks.Item
                   , QuickBooks.Logging
+                  , QuickBooks.QBText
                   , QuickBooks.Types
 
   build-depends:
@@ -121,6 +124,7 @@ test-suite api-tests
     , http-types
     , http-client-tls
     , interpolate
+    , MissingH
     , network-uri
     , text
     , fast-logger

--- a/quickbooks.cabal
+++ b/quickbooks.cabal
@@ -82,6 +82,7 @@ library
                        , http-types
                        , http-client-tls
                        , interpolate
+                       , network-uri
                        , text
                        , fast-logger
                        , time
@@ -120,6 +121,7 @@ test-suite api-tests
     , http-types
     , http-client-tls
     , interpolate
+    , network-uri
     , text
     , fast-logger
     , time

--- a/src/QuickBooks.hs
+++ b/src/QuickBooks.hs
@@ -201,6 +201,8 @@ queryItem'
 queryItem' apiConfig appConfig tok =
   queryQuickBooks' apiConfig appConfig tok . QueryItem
 
+-- queryAllItems :: OAuthToken -> IO (Either String ([QuickBooksItemResponse [Item]]))
+-- queryAllItems otk = queryQuickBooks tok . QueryAllItems
 
 ----------------
 -- Bundle R/Q --
@@ -515,6 +517,7 @@ queryQuickBooks' apiConfig appConfig tok query = do
     UpdateItem item                     -> updateItemRequest tok item
     DeleteItem item                     -> deleteItemRequest tok item
     QueryItem queryItemName             -> queryItemRequest tok queryItemName
+    --QueryAllItems                       -> queryAllItemRequest tok
     ReadBundle iId                      -> readBundleRequest tok iId
     QueryBundle queryBundleName         -> queryBundleRequest tok queryBundleName
     CreateCategory category             -> createCategoryRequest tok category

--- a/src/QuickBooks.hs
+++ b/src/QuickBooks.hs
@@ -58,6 +58,10 @@ module QuickBooks
   , deleteItem'
   , queryItem
   , queryItem'
+  , queryItemCount
+  , queryItemCount'
+  , queryMaxItemsFrom
+  , queryMaxItemsFrom'
   , readBundle
   , readBundle'
   , queryBundle
@@ -200,6 +204,38 @@ queryItem'
   -> IO (Either String (QuickBooksResponse [Item]))
 queryItem' apiConfig appConfig tok =
   queryQuickBooks' apiConfig appConfig tok . QueryItem
+
+
+queryItemCount
+  :: OAuthToken
+  -> IO (Either String (QuickBooksResponse Int))
+queryItemCount tok =
+  queryQuickBooks tok QueryCountItem
+
+queryItemCount'
+  :: APIConfig
+  -> AppConfig
+  -> OAuthToken
+  -> IO (Either String (QuickBooksResponse Int))
+queryItemCount' apiConfig appConfig tok =
+  queryQuickBooks' apiConfig appConfig tok QueryCountItem
+
+
+queryMaxItemsFrom
+  :: OAuthToken
+  -> Int
+  -> IO (Either String (QuickBooksResponse [Item]))
+queryMaxItemsFrom tok =
+  queryQuickBooks tok . QueryMaxItemsFrom
+
+queryMaxItemsFrom'
+  :: APIConfig
+  -> AppConfig
+  -> OAuthToken
+  -> Int
+  -> IO (Either String (QuickBooksResponse [Item]))
+queryMaxItemsFrom' apiConfig appConfig tok =
+  queryQuickBooks' apiConfig appConfig tok . QueryMaxItemsFrom
 
 -- queryAllItems :: OAuthToken -> IO (Either String ([QuickBooksItemResponse [Item]]))
 -- queryAllItems otk = queryQuickBooks tok . QueryAllItems
@@ -517,6 +553,8 @@ queryQuickBooks' apiConfig appConfig tok query = do
     UpdateItem item                     -> updateItemRequest tok item
     DeleteItem item                     -> deleteItemRequest tok item
     QueryItem queryItemName             -> queryItemRequest tok queryItemName
+    QueryCountItem                           -> countItemRequest tok
+    QueryMaxItemsFrom startIndex        -> queryMaxItemRequest tok startIndex
     --QueryAllItems                       -> queryAllItemRequest tok
     ReadBundle iId                      -> readBundleRequest tok iId
     QueryBundle queryBundleName         -> queryBundleRequest tok queryBundleName

--- a/src/QuickBooks.hs
+++ b/src/QuickBooks.hs
@@ -76,6 +76,10 @@ module QuickBooks
   , deleteCategory'
   , queryCategory
   , queryCategory'
+  , queryCategoryCount
+  , queryCategoryCount'
+  , queryMaxCategoriesFrom
+  , queryMaxCategoriesFrom'
   ) where
 
 import QuickBooks.Authentication
@@ -325,6 +329,43 @@ queryCategory' apiConfig appConfig tok =
 
 
 
+
+
+
+
+queryCategoryCount
+  :: OAuthToken
+  -> IO (Either String (QuickBooksResponse Int))
+queryCategoryCount tok =
+  queryQuickBooks tok QueryCountCategory
+
+queryCategoryCount'
+  :: APIConfig
+  -> AppConfig
+  -> OAuthToken
+  -> IO (Either String (QuickBooksResponse Int))
+queryCategoryCount' apiConfig appConfig tok =
+  queryQuickBooks' apiConfig appConfig tok QueryCountCategory
+
+  
+queryMaxCategoriesFrom
+  :: OAuthToken
+  -> Int
+  -> IO (Either String (QuickBooksResponse [Category]))
+queryMaxCategoriesFrom tok =
+  queryQuickBooks tok . QueryMaxCategoriesFrom
+
+queryMaxCategoriesFrom'
+  :: APIConfig
+  -> AppConfig
+  -> OAuthToken
+  -> Int
+  -> IO (Either String (QuickBooksResponse [Category]))
+queryMaxCategoriesFrom' apiConfig appConfig tok =
+  queryQuickBooks' apiConfig appConfig tok . QueryMaxCategoriesFrom
+
+
+
 -- Unused DocTest (removed 6-26-17)
 -- | Create an invoice.
 --
@@ -553,7 +594,7 @@ queryQuickBooks' apiConfig appConfig tok query = do
     UpdateItem item                     -> updateItemRequest tok item
     DeleteItem item                     -> deleteItemRequest tok item
     QueryItem queryItemName             -> queryItemRequest tok queryItemName
-    QueryCountItem                           -> countItemRequest tok
+    QueryCountItem                      -> countItemRequest tok
     QueryMaxItemsFrom startIndex        -> queryMaxItemRequest tok startIndex
     --QueryAllItems                       -> queryAllItemRequest tok
     ReadBundle iId                      -> readBundleRequest tok iId
@@ -563,6 +604,8 @@ queryQuickBooks' apiConfig appConfig tok query = do
     UpdateCategory category             -> updateCategoryRequest tok category
     DeleteCategory category             -> deleteCategoryRequest tok category
     QueryCategory queryCategoryName     -> queryCategoryRequest tok queryCategoryName
+    QueryCountCategory                  -> countCategoryRequest tok
+    QueryMaxCategoriesFrom startIndex   -> queryMaxCategoryRequest tok startIndex
 
 queryQuickBooksOAuth :: Maybe OAuthToken
                      -> QuickBooksOAuthQuery a

--- a/src/QuickBooks/Authentication.hs
+++ b/src/QuickBooks/Authentication.hs
@@ -22,6 +22,7 @@ import Network.HTTP.Client (Manager
                            ,parseUrl
                            ,httpLbs)
 import Network.HTTP.Types.URI (parseSimpleQuery)
+import Network.URI               (escapeURIString, isUnescapedInURI, isUnescapedInURIComponent)
 import Web.Authenticate.OAuth (signOAuth
                               ,newCredential
                               ,emptyCredential
@@ -53,7 +54,7 @@ disconnectRequest :: AppEnv
                   => OAuthToken
                   -> IO (Either String (QuickBooksResponse ()))
 disconnectRequest tok = do
-  req  <- parseUrl $ disconnectURL
+  req  <- parseUrl $ escapeURIString isUnescapedInURI $ disconnectURL
   req' <- oauthSignRequest tok req
   void $ httpLbs req' ?manager
   logAPICall' req'
@@ -66,7 +67,7 @@ getTokens :: AppEnv
           -> ((?appConfig :: AppConfig) => Request -> IO Request) -- ^ Signing function
           -> IO (Maybe OAuthToken)
 getTokens tokenURL parameterName parameterValue signRequest = do
-  request  <- parseUrl $ concat [tokenURL, parameterName, parameterValue]
+  request  <- parseUrl $ escapeURIString isUnescapedInURI $ concat [tokenURL, parameterName, parameterValue]
   request' <- signRequest request { method="POST", requestBody = RequestBodyLBS "" }
   response <- httpLbs request' ?manager
   logAPICall' request'

--- a/src/QuickBooks/Bundle.hs
+++ b/src/QuickBooks/Bundle.hs
@@ -27,6 +27,7 @@ module QuickBooks.Bundle
 import QuickBooks.Authentication
 import QuickBooks.Logging
 import QuickBooks.Types
+import QuickBooks.QBText
 
 import Data.Aeson                (eitherDecode)
 import Data.String.Interpolate   (i)

--- a/src/QuickBooks/Category.hs
+++ b/src/QuickBooks/Category.hs
@@ -30,6 +30,7 @@ module QuickBooks.Category
 import QuickBooks.Authentication
 import QuickBooks.Logging
 import QuickBooks.Types
+import QuickBooks.QBText
 
 import Data.Aeson                (encode, eitherDecode)
 import Data.String.Interpolate   (i)

--- a/src/QuickBooks/Customer.hs
+++ b/src/QuickBooks/Customer.hs
@@ -26,6 +26,7 @@ module QuickBooks.Customer
 import QuickBooks.Authentication
 import QuickBooks.Logging
 import QuickBooks.Types
+import QuickBooks.QBText
 
 import qualified Data.Aeson as Aeson
 import Data.String.Interpolate (i)
@@ -57,7 +58,7 @@ queryCustomerRequest tok queryCustomerName = do
     Left er -> return (Left er)
     Right (QuickBooksCustomerResponse allCustomers) ->
       return $ Right $ QuickBooksCustomerResponse $
-        filter (\Customer{..} -> customerDisplayName == queryCustomerName) allCustomers
+        filter (\Customer{..} -> (textFromQBText customerDisplayName) == queryCustomerName) allCustomers
   where
     query :: String
     query = "SELECT * FROM Customer"

--- a/src/QuickBooks/Customer.hs
+++ b/src/QuickBooks/Customer.hs
@@ -32,6 +32,8 @@ import Data.String.Interpolate (i)
 import Data.Text (Text)
 import Network.HTTP.Client
 import Network.HTTP.Types.Header (hAccept)
+import Network.URI               (escapeURIString, isUnescapedInURI, isUnescapedInURIComponent)
+
 
 -- GET /v3/company/<companyID>/query=<selectStatement>
 
@@ -41,7 +43,8 @@ queryCustomerRequest :: APIEnv
                      -> IO (Either String (QuickBooksResponse [Customer]))
 queryCustomerRequest tok queryCustomerName = do
   let apiConfig = ?apiConfig
-  let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}|]
+  let uriComponent =  escapeURIString isUnescapedInURIComponent [i|#{query}|]
+  let queryURI = parseUrl $ [i|#{queryURITemplate apiConfig}#{uriComponent}|]
   req <- oauthSignRequest tok =<< queryURI
   let oauthHeaders = requestHeaders req
   let req' = req { method = "GET"

--- a/src/QuickBooks/Item.hs
+++ b/src/QuickBooks/Item.hs
@@ -36,6 +36,7 @@ import Data.String.Interpolate   (i)
 import Data.Text                 (Text)
 import Network.HTTP.Client
 import Network.HTTP.Types.Header (hAccept, hContentType)
+import Network.URI               (escapeURIString, isUnescapedInURI, isUnescapedInURIComponent)
 
 -- | Create an item. (Supply a new Item WITHOUT an id field)
 createItemRequest :: APIEnv
@@ -51,7 +52,7 @@ readItemRequest ::  APIEnv
                      -> IO (Either String (QuickBooksResponse [Item]))
 readItemRequest tok iId = do
   let apiConfig = ?apiConfig
-  req  <- oauthSignRequest tok =<< parseUrl [i|#{itemURITemplate apiConfig}/#{iId}|]
+  req  <- oauthSignRequest tok =<< parseUrl (escapeURIString isUnescapedInURI [i|#{itemURITemplate apiConfig}/#{iId}|])
   let oauthHeaders = requestHeaders req
   let req' = req{method = "GET", requestHeaders = oauthHeaders ++ [(hAccept, "application/json")]}
   resp <-  httpLbs req' ?manager
@@ -83,7 +84,7 @@ postItem :: APIEnv
             -> IO (Either String (QuickBooksResponse [Item]))
 postItem tok item = do
   let apiConfig = ?apiConfig
-  req <- parseUrl [i|#{itemURITemplate apiConfig}?|]
+  req <- parseUrl $ [i|#{itemURITemplate apiConfig}?|]
   req' <- oauthSignRequest tok req{ method         = "POST"
                                   , requestBody    = RequestBodyLBS $ encode item
                                   , requestHeaders = [ (hAccept, "application/json")
@@ -105,7 +106,8 @@ queryItemRequest :: APIEnv
                  -> IO (Either String (QuickBooksResponse [Item]))
 queryItemRequest tok queryItemName = do
   let apiConfig = ?apiConfig
-  let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}#{itemSearch}|]
+  let uriComponent = escapeURIString isUnescapedInURIComponent [i|#{query}#{itemSearch}|]
+  let queryURI = parseUrl $ [i|#{queryURITemplate apiConfig}#{uriComponent}|]
   req <- oauthSignRequest tok =<< queryURI
   let oauthHeaders = requestHeaders req
   let req' = req { method = "GET"
@@ -129,6 +131,47 @@ queryItemRequest tok queryItemName = do
     itemSearch = if (itemName == "")
       then ""                                  -- All Items
       else [i| Where Name='#{queryItemName}'|] -- Item that Matchs Name
+
+--queryAllItems with pagination at the max of 1000
+-- queryAllItemRequest :: APIEnv => OAuthToken -> IO (Either String ([QuickBooksItemResponse [Item]]))
+-- queryAllItemRequest tok = do
+--   let apiConfig = ?apiConfig
+--   paginationStrings <- liftIO $ getPagination tok
+--   let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}#{itemSearch}|]
+--   req <- oauthSignRequest tok =<< queryURI
+--   let oauthHeaders = requestHeaders req
+--   let req' = req { method = "GET"
+--                  , requestHeaders = oauthHeaders ++ [(hAccept, "application/json")]
+--                  }
+--   resp <- httpLbs req' ?manager
+--   logAPICall req'
+--   let eitherFoundItems = eitherDecode (responseBody resp)
+--   case eitherFoundItems of
+--     Left er -> return (Left er)
+--     Right (QuickBooksItemResponse foundItems) ->
+--       return $ Right $ QuickBooksItemResponse $ foundItems
+--         -- filter (\Item{..} -> itemName == queryItemName) FoundItems
+--   where
+--     query :: String
+--     query = "SELECT * FROM Item"
+
+
+-- -- Determines the pagination strings
+-- getPagination :: OAuthToken -> [Text]
+-- getPagination tok = do
+--   let apiConfig = ?apiConfig
+--   let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}]
+--   req <- oauthSignRequest tok =<< queryURI
+--   let oauthHeaders = requestHeaders req
+--   let req' = req { method = "GET"
+--                  , requestHeaders = oauthHeaders ++ [(hAccept, "application/json")]
+--                  }
+--   resp <- httpLbs req' ?manager
+--   logAPICall req'
+
+--   where
+--     query :: String
+--     query = "SELECT Count(*) From Item"
 
 -- Template for queries
 queryURITemplate :: APIConfig -> String

--- a/src/QuickBooks/Item.hs
+++ b/src/QuickBooks/Item.hs
@@ -141,7 +141,7 @@ queryMaxItemRequest :: APIEnv
                  -> IO (Either String (QuickBooksResponse [Item]))
 queryMaxItemRequest tok startIndex = do
   let apiConfig = ?apiConfig
-  let uriComponent = escapeURIString isUnescapedInURIComponent [i|#{query}#{pagination}|]
+  let uriComponent = escapeURIString isUnescapedInURIComponent [i|#{query} #{pagination}|]
   let queryURI = parseUrl $ [i|#{queryURITemplate apiConfig}#{uriComponent}|]
   req <- oauthSignRequest tok =<< queryURI
   let oauthHeaders = requestHeaders req

--- a/src/QuickBooks/Item.hs
+++ b/src/QuickBooks/Item.hs
@@ -30,6 +30,7 @@ module QuickBooks.Item
 import QuickBooks.Authentication
 import QuickBooks.Logging
 import QuickBooks.Types
+import QuickBooks.QBText
 
 import Data.Aeson                (encode, eitherDecode)
 import Data.String.Interpolate   (i)

--- a/src/QuickBooks/Item.hs
+++ b/src/QuickBooks/Item.hs
@@ -185,48 +185,7 @@ countItemRequest tok = do
   where
     query :: String
     query = "SELECT COUNT(*) FROM Item"
- 
 
---queryAllItems with pagination at the max of 1000
--- queryAllItemRequest :: APIEnv => OAuthToken -> IO (Either String ([QuickBooksItemResponse [Item]]))
--- queryAllItemRequest tok = do
---   let apiConfig = ?apiConfig
---   paginationStrings <- liftIO $ getPagination tok
---   let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}#{itemSearch}|]
---   req <- oauthSignRequest tok =<< queryURI
---   let oauthHeaders = requestHeaders req
---   let req' = req { method = "GET"
---                  , requestHeaders = oauthHeaders ++ [(hAccept, "application/json")]
---                  }
---   resp <- httpLbs req' ?manager
---   logAPICall req'
---   let eitherFoundItems = eitherDecode (responseBody resp)
---   case eitherFoundItems of
---     Left er -> return (Left er)
---     Right (QuickBooksItemResponse foundItems) ->
---       return $ Right $ QuickBooksItemResponse $ foundItems
---         -- filter (\Item{..} -> itemName == queryItemName) FoundItems
---   where
---     query :: String
---     query = "SELECT * FROM Item"
-
-
--- -- Determines the pagination strings
--- getPagination :: OAuthToken -> [Text]
--- getPagination tok = do
---   let apiConfig = ?apiConfig
---   let queryURI = parseUrl [i|#{queryURITemplate apiConfig}#{query}]
---   req <- oauthSignRequest tok =<< queryURI
---   let oauthHeaders = requestHeaders req
---   let req' = req { method = "GET"
---                  , requestHeaders = oauthHeaders ++ [(hAccept, "application/json")]
---                  }
---   resp <- httpLbs req' ?manager
---   logAPICall req'
-
---   where
---     query :: String
---     query = "SELECT Count(*) From Item"
 
 -- Template for queries
 queryURITemplate :: APIConfig -> String

--- a/src/QuickBooks/QBText.hs
+++ b/src/QuickBooks/QBText.hs
@@ -1,0 +1,37 @@
+module QuickBooks.QBText ( QBText
+                         , QBTextConstructionError
+                         , filterTextForQB
+                         , textFromQBText) where
+
+import           Data.Text
+import qualified Data.List.Utils as L
+import           Data.Aeson
+
+-- | Text that has been filtered to be valid in all quickbooks context
+newtype QBText = QBText {unQBText :: Text}
+  deriving (Eq, Show)
+
+instance ToJSON QBText where
+    toJSON (QBText txt) = toJSON txt
+
+instance FromJSON QBText where
+    parseJSON (String txt) = return $ QBText txt
+    parseJSON _            = fail "expecting String in FromJSON instance for QBText"
+
+data QBTextConstructionError = QBTextErrorBadCharacter
+  deriving (Show, Eq, Ord)
+
+filterTextForQB :: Text -> Either QBTextConstructionError QBText
+filterTextForQB inputText = do
+  Right $ QBText $ replaceColon $ trimWhiteSpace inputText
+
+textFromQBText :: QBText -> Text
+textFromQBText qbText = unQBText qbText
+
+trimWhiteSpace :: Text -> Text
+trimWhiteSpace text = do
+  Data.Text.reverse . Data.Text.dropWhile (== ' ') . Data.Text.reverse $ Data.Text.dropWhile (== ' ') text
+
+replaceColon :: Text -> Text
+replaceColon text =
+  pack $ L.replace ":" "" (unpack $ text)

--- a/src/QuickBooks/Types.hs
+++ b/src/QuickBooks/Types.hs
@@ -39,6 +39,7 @@ import           Prelude             hiding (lines)
 import qualified Text.Email.Validate as E (EmailAddress)
 import           System.Log.FastLogger (LoggerSet)
 import           Network.HTTP.Client   (Manager)
+import           QuickBooks.QBText
 
 type Logger = LoggerSet
 
@@ -505,31 +506,31 @@ data Invoice = Invoice
   , invoiceSyncToken             :: !(Maybe SyncToken)
   , invoiceMetaData              :: !(Maybe ModificationMetaData)
   , invoiceCustomField           :: !(Maybe [CustomField])
-  , invoiceDocNumber             :: !(Maybe Text)
-  , invoiceTxnDate               :: !(Maybe Text)
+  , invoiceDocNumber             :: !(Maybe QBText)
+  , invoiceTxnDate               :: !(Maybe QBText)
   , invoiceDepartmentRef         :: !(Maybe DepartmentRef)
   , invoiceCurrencyRef           :: !(Maybe CurrencyRef) -- Non-US
   , invoiceExchangeRate          :: !(Maybe Double) -- Non-US
-  , invoicePrivateNote           :: !(Maybe Text)
+  , invoicePrivateNote           :: !(Maybe QBText)
   , invoiceLinkedTxn             :: !(Maybe [LinkedTxn])
   , invoiceLine                  :: ![Line]
   , invoiceTxnTaxDetail          :: !(Maybe TxnTaxDetail)
   , invoiceCustomerRef           :: !CustomerRef
-  , invoiceCustomerMemo          :: !(Maybe Text)
+  , invoiceCustomerMemo          :: !(Maybe QBText)
   , invoiceBillAddr              :: !(Maybe BillAddr)
   , invoiceShipAddr              :: !(Maybe ShipAddr)
   , invoiceClassRef              :: !(Maybe ClassRef)
   , invoiceSalesTermRef          :: !(Maybe SalesTermRef)
-  , invoiceDueDate               :: !(Maybe Text)
+  , invoiceDueDate               :: !(Maybe QBText)
   , invoiceGlobalTaxCalculation  :: !(Maybe GlobalTaxModel) -- Non-US
   , invoiceShipMethodRef         :: !(Maybe ShipMethodRef)
-  , invoiceShipDate              :: !(Maybe Text)
-  , invoiceTrackingNum           :: !(Maybe Text)
+  , invoiceShipDate              :: !(Maybe QBText)
+  , invoiceTrackingNum           :: !(Maybe QBText)
   , invoiceTotalAmt              :: !(Maybe Double)
   , invoiceHomeTotalAmt          :: !(Maybe Double) -- Non-US
   , invoiceApplyTaxAfterDiscount :: !(Maybe Bool)
-  , invoicePrintStatus           :: !(Maybe Text)
-  , invoiceEmailStatus           :: !(Maybe Text)
+  , invoicePrintStatus           :: !(Maybe QBText)
+  , invoiceEmailStatus           :: !(Maybe QBText)
   , invoiceBillEmail             :: !(Maybe EmailAddress)
   , invoiceDeliveryInfo          :: !(Maybe DeliveryInfo)
   , invoiceBalance               :: !(Maybe Double)
@@ -537,7 +538,7 @@ data Invoice = Invoice
   , invoiceDeposit               :: !(Maybe Double)
 
   , invoiceAllowIPNPayment       :: !(Maybe Bool)
-  , invoiceDomain                :: !(Maybe Text)
+  , invoiceDomain                :: !(Maybe QBText)
   , invoiceSparse                :: !(Maybe Bool)
   }
   deriving (Show, Eq)
@@ -605,18 +606,18 @@ data CustomerResponse = CustomerResponse
   deriving (Eq, Show)
 
 data Customer = Customer
-  { customerId                      :: !(Maybe Text)
+  { customerId                      :: !(Maybe QBText)
   , customerSyncToken               :: !(Maybe SyncToken)
   , customerMetaData                :: !(Maybe ModificationMetaData)
-  , customerTitle                   :: !(Maybe Text) -- def null
-  , customerGivenName               :: !(Maybe Text) -- max 25 def null
-  , customerMiddleName              :: !(Maybe Text) -- max 25, def null
-  , customerFamilyName              :: !(Maybe Text) -- max 25, def null
-  , customerSuffix                  :: !(Maybe Text) -- max 10, def null
-  , customerFullyQualifiedName      :: !(Maybe Text)
-  , customerCompanyName             :: !(Maybe Text) -- max 50, def null
-  , customerDisplayName             :: !Text -- unique
-  , customerPrintOnCheckName        :: !(Maybe Text) -- max 100
+  , customerTitle                   :: !(Maybe QBText) -- def null
+  , customerGivenName               :: !(Maybe QBText) -- max 25 def null
+  , customerMiddleName              :: !(Maybe QBText) -- max 25, def null
+  , customerFamilyName              :: !(Maybe QBText) -- max 25, def null
+  , customerSuffix                  :: !(Maybe QBText) -- max 10, def null
+  , customerFullyQualifiedName      :: !(Maybe QBText)
+  , customerCompanyName             :: !(Maybe QBText) -- max 50, def null
+  , customerDisplayName             :: !QBText -- unique
+  , customerPrintOnCheckName        :: !(Maybe QBText) -- max 100
   , customerActive                  :: !(Maybe Bool) -- def true
   , customerPrimaryPhone            :: !(Maybe TelephoneNumber)
   , customerAlternatePhone          :: !(Maybe TelephoneNumber)
@@ -628,7 +629,7 @@ data Customer = Customer
   , customerTaxable                 :: !(Maybe Bool)
   , customerBillAddr                :: !(Maybe BillAddr)
   , customerShipAddr                :: !(Maybe ShipAddr)
-  , customerNotes                   :: !(Maybe Text) -- max 2000
+  , customerNotes                   :: !(Maybe QBText) -- max 2000
   , customerJob                     :: !(Maybe Bool) -- def false or null
   , customerBillWithParent          :: !(Maybe Bool) -- def false or null
   , customerParentRef               :: !(Maybe CustomerRef)
@@ -636,11 +637,11 @@ data Customer = Customer
   , customerSalesTermRef            :: !(Maybe SalesTermRef)
   , customerPaymentMethodRef        :: !(Maybe Reference)
   , customerBalance                 :: !(Maybe Double)
-  , customerOpenBalanceDate         :: !(Maybe Text)
+  , customerOpenBalanceDate         :: !(Maybe QBText)
   , customerBalanceWithJobs         :: !(Maybe Double)
   , customerCurrencyRef             :: !(Maybe CurrencyRef)
-  , customerPreferredDeliveryMethod :: !(Maybe Text)
-  , customerResaleNum               :: !(Maybe Text) -- max 15
+  , customerPreferredDeliveryMethod :: !(Maybe QBText)
+  , customerResaleNum               :: !(Maybe QBText) -- max 15
   }
   deriving (Eq, Show)
 
@@ -650,11 +651,11 @@ data ItemResponse = ItemResponse
   deriving (Eq, Show)
 
 data Item = Item
-  { itemId                   :: !(Maybe Text)
+  { itemId                   :: !(Maybe QBText)
   , itemSyncToken            :: !(Maybe SyncToken)
   , itemMetaData             :: !(Maybe ModificationMetaData)
-  , itemName                 :: !Text -- max 100
-  , itemDescription          :: !(Maybe Text) -- max 4000
+  , itemName                 :: !QBText -- max 100
+  , itemDescription          :: !(Maybe QBText) -- max 4000
   , itemActive               :: !(Maybe Bool) -- def true
   , itemSubItem              :: !(Maybe Bool) -- def false or null
   , itemParentRef            :: !(Maybe ItemRef) -- def null
@@ -679,14 +680,14 @@ data Item = Item
   deriving (Eq, Show)
 
 data Bundle = Bundle
-  { bundleId                 :: !(Maybe Text)
+  { bundleId                 :: !(Maybe QBText)
   , bundleSyncToken          :: !(Maybe SyncToken)
   , bundleMetaData           :: !(Maybe ModificationMetaData)
-  , bundleName               :: !Text -- max 100
-  , bundleSKU                :: !(Maybe Text)
+  , bundleName               :: !QBText -- max 100
+  , bundleSKU                :: !(Maybe QBText)
   , bundleActive             :: !(Maybe Bool) -- Always true for categories
-  , bundleDescription        :: !(Maybe Text) -- max 4000
-  , bundleFullyQualifiedName :: !(Maybe Text)    -- readonly, system gen
+  , bundleDescription        :: !(Maybe QBText) -- max 4000
+  , bundleFullyQualifiedName :: !(Maybe QBText)    -- readonly, system gen
   , bundleTaxable            :: !(Maybe Bool) -- US only
   , bundleUnitPrice          :: !(Maybe Double) -- max 99999999999, def 0
   , bundleType               :: !(Maybe Text) -- Set to "Group" for bundles
@@ -697,15 +698,15 @@ data Bundle = Bundle
   deriving (Eq, Show)
 
 data Category = Category
-  { categoryId                 :: !(Maybe Text)
+  { categoryId                 :: !(Maybe QBText)
   , categorySyncToken          :: !(Maybe SyncToken)
   , categoryMetaData           :: !(Maybe ModificationMetaData)
-  , categoryName               :: !Text -- max 100
+  , categoryName               :: !QBText -- max 100
   , categoryActive             :: !(Maybe Bool) -- Always true for categories
   , categorySubItem            :: !(Maybe Bool) -- true -> Sub-category, false -> top-level (default)
   , categoryParentRef          :: !(Maybe Reference) --
   , categoryLevel              :: !(Maybe Integer)   -- 0 to 3
-  , categoryFullyQualifiedName :: !(Maybe Text)    -- readonly
+  , categoryFullyQualifiedName :: !(Maybe QBText)    -- readonly
   , categoryType               :: !(Maybe Text)
   }
   deriving (Eq, Show)

--- a/src/QuickBooks/Types.hs
+++ b/src/QuickBooks/Types.hs
@@ -231,6 +231,8 @@ data QuickBooksRequest a where
   UpdateCategory          :: Category -> QuickBooksQuery [Category]
   DeleteCategory          :: Category -> QuickBooksQuery DeletedCategory
   QueryCategory           :: Text -> QuickBooksQuery [Category]
+  QueryCountCategory      :: (QuickBooksQuery Int)
+  QueryMaxCategoriesFrom  :: Int -> QuickBooksQuery [Category]
 
 newtype InvoiceId = InvoiceId {unInvoiceId :: Text}
   deriving (Show, Eq, FromJSON, ToJSON)

--- a/src/QuickBooks/Types.hs
+++ b/src/QuickBooks/Types.hs
@@ -127,6 +127,18 @@ data instance QuickBooksResponse [Bundle] =
 data instance QuickBooksResponse [Category] =
   QuickBooksCategoryResponse { quickBooksResponseCategory :: [Category] }
 
+data instance QuickBooksResponse Int =
+  QuickBooksCountResponse { quickBooksCountResponse :: Int}
+
+instance FromJSON (QuickBooksResponse Int) where
+  parseJSON (Object o) = parseQueryResponse o
+    where
+      parseQueryResponse obj = do
+        qResponse <- obj .: "QueryResponse"
+        parseInt qResponse <|> (return $ QuickBooksCountResponse (-1))
+      parseInt obj = QuickBooksCountResponse <$> obj .: "totalCount"
+  parseJSON _          = fail "Could not parse count response from QuickBooks"
+
 instance FromJSON (QuickBooksResponse Invoice) where
   parseJSON (Object o) = QuickBooksInvoiceResponse `fmap` (o .: "Invoice")
   parseJSON _          = fail "Could not parse invoice response from QuickBooks"
@@ -208,6 +220,8 @@ data QuickBooksRequest a where
   UpdateItem              :: Item -> QuickBooksQuery [Item]
   DeleteItem              :: Item -> QuickBooksQuery [Item]
   QueryItem               :: Text -> QuickBooksQuery [Item]
+  QueryCountItem          :: (QuickBooksQuery Int)
+  QueryMaxItemsFrom       :: Int -> QuickBooksQuery [Item]
 
   ReadBundle              :: Text -> QuickBooksQuery [Bundle]
   QueryBundle             :: Text -> QuickBooksQuery [Bundle]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -37,6 +37,8 @@ tests tok = testGroup "tests" [ testCase "Query Customer" $ queryCustomerTest to
                               , testCase "Update Category" $ updateCategoryTest tok
                               , testCase "Delete Category" $ deleteCategoryTest tok
                               , testCase "Query Item" $ queryItemTest tok
+                              , testCase "Query Count Items" $ queryCountTest tok
+                              , testCase "Query Max Items" $ queryMaxItemTest tok
                               , testCase "Create Item" $ createItemTest tok
                               , testCase "Read Item" $ readItemTest tok
                               , testCase "Update Item" $ updateItemTest tok
@@ -132,6 +134,25 @@ queryItemTest oAuthToken = do
     Right (QuickBooksItemResponse (item:_)) -> do
       let (Right existingId) = filterTextForQB "2"
       assertBool (show $ itemId item) (itemId item == Just existingId)
+
+---- Query Max Item ----
+queryMaxItemTest :: OAuthToken -> Assertion
+queryMaxItemTest oAuthToken = do
+  eitherQueryItems <- queryMaxItemsFrom oAuthToken 1
+  case eitherQueryItems of
+    Left _ ->
+      assertEither "Failed to query item" eitherQueryItems
+    Right (QuickBooksItemResponse (item:_)) -> do
+      assertEither "Queried for max size" eitherQueryItems
+
+queryCountTest :: OAuthToken -> Assertion
+queryCountTest oAuthToken = do
+  eitherCount <- queryItemCount oAuthToken
+  case eitherCount of
+    Left _ ->
+      assertEither "Failed to query item count" eitherCount
+    Right (QuickBooksCountResponse size) ->
+      assertEither "Queried the count" eitherCount
 
 ---------------------
 -- Bundle CRUD-Q --

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import           Data.String
 import qualified Data.Text             as T
 import           Data.Text             (Text)
 import           QuickBooks.Types
+import           QuickBooks.QBText
 import           System.Environment    (getEnvironment)
 import qualified Text.Email.Validate   as E (EmailAddress, emailAddress)
 
@@ -58,10 +59,11 @@ queryCustomerTest oAuthToken = do
   eitherQueryCustomer <-
       queryCustomer oAuthToken "Rondonuwu Fruit and Vegi"
   case eitherQueryCustomer of
-    Right (QuickBooksCustomerResponse (customer:_)) ->
-      assertBool (show $ customerId customer) (customerId customer == Just "21")
-    _ ->
+    Left _ ->
       assertEither "Faild to query customer" eitherQueryCustomer
+    Right (QuickBooksCustomerResponse (customer:_)) -> do
+      let (Right existingId) = filterTextForQB "21"
+      assertBool (show $ customerId customer) (customerId customer == Just existingId)
 
 -----------------
 -- Item CRUD-Q --
@@ -84,7 +86,7 @@ readItemTest oAuthToken = do
   testItem <- makeTestItem
   Right (QuickBooksItemResponse (cItem:_)) <- createItem oAuthToken testItem
   let (Just iId) = itemId cItem
-  eitherReadItem <- readItem oAuthToken iId
+  eitherReadItem <- readItem oAuthToken $ textFromQBText iId
   case eitherReadItem of
     Left _ -> do
       deleteItem oAuthToken cItem
@@ -125,10 +127,11 @@ queryItemTest :: OAuthToken -> Assertion
 queryItemTest oAuthToken = do
   eitherQueryItem <- queryItem oAuthToken "Hours"
   case eitherQueryItem of
-    Right (QuickBooksItemResponse (item:_)) ->
-      assertBool (show $ itemId item) (itemId item == Just "2")
-    _ ->
+    Left _ ->
       assertEither "Failed to query item" eitherQueryItem
+    Right (QuickBooksItemResponse (item:_)) -> do
+      let (Right existingId) = filterTextForQB "2"
+      assertBool (show $ itemId item) (itemId item == Just existingId)
 
 ---------------------
 -- Bundle CRUD-Q --
@@ -137,23 +140,25 @@ queryItemTest oAuthToken = do
 ---- Read Bundle ----
 readBundleTest :: OAuthToken -> Assertion
 readBundleTest oAuthToken = do
-  let existingBundleId = "208" -- this MUST be created in QB Online for the test to pass
+  let (Right existingId) = filterTextForQB "208"
+  let existingBundleId = existingId -- this MUST be created in QB Online for the test to pass
                             -- Replace the number the id for the existing bundle
                             -- It can be obtained by querying the bundle name below
                             -- Or through the API Explorer at https://developer.intuit.com/v2/apiexplorer?apiname=V3QBO#?id=Item
                             -- With select * from item where Type='Group'
-  eitherReadBundle <- readBundle oAuthToken existingBundleId
+  eitherReadBundle <- readBundle oAuthToken (textFromQBText existingBundleId)
   case eitherReadBundle of
     Left _ -> do
       assertEither "Failed to read bundle" eitherReadBundle
     Right (QuickBooksBundleResponse (rBundle:_)) -> do
       let rBundleId = fromJust (bundleId rBundle)
-      assertBool "Read the Bundle" (rBundleId == existingBundleId)
+      assertBool "Read the Bundle" ((textFromQBText rBundleId) == (textFromQBText existingBundleId))
 
 ---- Query Bundle ----
 queryBundleTest :: OAuthToken -> Assertion
 queryBundleTest oAuthToken = do
-  let existingBundleId = "208" -- this MUST be created in QB Online for the test to pass
+  let (Right existingId) = filterTextForQB "208"
+  let existingBundleId = existingId -- this MUST be created in QB Online for the test to pass
                             -- Replace the number the id for the existing bundle
                             -- It can be obtained by querying the bundle name below
                             -- Or through the API Explorer at https://developer.intuit.com/v2/apiexplorer?apiname=V3QBO#?id=Item
@@ -186,7 +191,7 @@ createCategoryTest oAuthToken = do
         Nothing ->
           assertBool "Faild to get category id" False
         Just categoryId -> do
-          testCategory2 <- makeTestCategory2 categoryId
+          testCategory2 <- makeTestCategory2 $ textFromQBText categoryId
           resp2 <- createCategory oAuthToken testCategory2
           case resp2 of
             Left err -> assertEither ("My custom error message: " ++ err) resp2
@@ -204,7 +209,7 @@ readCategoryTest oAuthToken = do
   testCategory <- makeTestCategory
   Right (QuickBooksCategoryResponse (cCategory:_)) <- createCategory oAuthToken testCategory
   let (Just iId) = categoryId cCategory
-  eitherReadCategory <- readCategory oAuthToken iId
+  eitherReadCategory <- readCategory oAuthToken $ textFromQBText iId
   case eitherReadCategory of
     Left _ -> do
       deleteCategory oAuthToken cCategory
@@ -218,15 +223,19 @@ updateCategoryTest :: OAuthToken -> Assertion
 updateCategoryTest oAuthToken = do
   testCategory <- makeTestCategory
   Right (QuickBooksCategoryResponse (cCategory:_)) <- createCategory oAuthToken testCategory
-  let nCategory = cCategory { categoryName = ( T.append (categoryName cCategory) "C"), categoryId = (categoryId cCategory) }
-  eitherUpdateCategory <- updateCategory oAuthToken nCategory
-  case eitherUpdateCategory of
-    Left _ -> do
-      deleteCategory oAuthToken cCategory
-      assertEither "Failed to update invoice" eitherUpdateCategory
-    Right (QuickBooksCategoryResponse (uCategory:_)) -> do
-      deleteCategory oAuthToken uCategory
-      assertBool "Updated the Category" (categoryName cCategory /= categoryName uCategory)
+  let eitherCreatedCategoryName = filterTextForQB $ T.append (textFromQBText $ categoryName cCategory) "C"
+  case eitherCreatedCategoryName of
+    Left err -> assertBool "Couldn't make QBText from the created QB Item?" False
+    Right cCategoryName -> do
+      let nCategory = cCategory { categoryName = cCategoryName, categoryId = (categoryId cCategory) }
+      eitherUpdateCategory <- updateCategory oAuthToken nCategory
+      case eitherUpdateCategory of
+        Left _ -> do
+          deleteCategory oAuthToken cCategory
+          assertEither "Failed to update invoice" eitherUpdateCategory
+        Right (QuickBooksCategoryResponse (uCategory:_)) -> do
+          deleteCategory oAuthToken uCategory
+          assertBool "Updated the Category" (categoryName cCategory /= categoryName uCategory)
 
 ---- Delete Category ----
 deleteCategoryTest :: OAuthToken -> Assertion
@@ -245,10 +254,11 @@ queryCategoryTest :: OAuthToken -> Assertion
 queryCategoryTest oAuthToken = do
   eitherQueryCategory <- queryCategory oAuthToken "Cat 1"
   case eitherQueryCategory of
-    Right (QuickBooksCategoryResponse (category:_)) ->
-      assertBool (show $ categoryId category) (categoryId category == Just "91")
-    _ ->
+    Left _ ->
       assertEither "Failed to query category" eitherQueryCategory
+    Right (QuickBooksCategoryResponse (category:_)) -> do
+      let (Right existingId) = filterTextForQB "91"
+      assertBool (show $ categoryId category) (categoryId category == (Just existingId))
 
 
 
@@ -461,23 +471,29 @@ makeTestBundleGroupDetail = do
         { itemRef = (Just testItemRef2)
         , itemQty = (Just 4)
         }
-  return $ ItemGroupDetail 
+  return $ ItemGroupDetail
     { itemGroupLine = (Just [testItemLine1, testItemLine2]) }
 
-getTestItemName :: IO Text
+getTestItemName :: IO QBText
 getTestItemName = do
   arbInt <- generate (choose (0, 100000000000000000) :: Gen Int)
-  return $ T.pack $ "testItemName" ++ show arbInt
+  -- Ignoring case check (Should always be a QBText)
+  let (Right eitherName) = filterTextForQB $ T.pack $ "testItemName" ++ show arbInt
+  return eitherName 
 
-getTestBundleName :: IO Text
+getTestBundleName :: IO QBText
 getTestBundleName = do
   arbInt <- generate (choose (0, 100000000000000000) :: Gen Int)
-  return $ T.pack $ "testBundleName" ++ show arbInt
+  -- Ignoring case check (Should always be a QBText)
+  let (Right eitherName) = filterTextForQB $ T.pack $ "testBundleName" ++ show arbInt
+  return eitherName 
 
-getTestCategoryName :: IO Text
+getTestCategoryName :: IO QBText
 getTestCategoryName = do
   arbInt <- generate (choose (0, 100000000000000000) :: Gen Int)
-  return $ T.pack $ "testCategoryName" ++ show arbInt
+  -- Ignoring case check (Should always be a QBText)
+  let (Right eitherName) = filterTextForQB $ T.pack $ "testCategoryName" ++ show arbInt
+  return eitherName 
 
 makeTestItem :: IO Item
 makeTestItem = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -32,12 +32,14 @@ tests tok = testGroup "tests" [ testCase "Query Customer" $ queryCustomerTest to
                               , testCase "Query Bundle" $ queryBundleTest tok
                               , testCase "Read Bundle" $ readBundleTest tok
                               , testCase "Query Category" $ queryCategoryTest tok
+                              , testCase "Query Count Categories" $ queryCountCategoryTest tok
+                              , testCase "Query Max Categories" $ queryMaxCategoryTest tok
                               , testCase "Create Category" $ createCategoryTest tok
                               , testCase "Read Category" $ readCategoryTest tok
                               , testCase "Update Category" $ updateCategoryTest tok
                               , testCase "Delete Category" $ deleteCategoryTest tok
                               , testCase "Query Item" $ queryItemTest tok
-                              , testCase "Query Count Items" $ queryCountTest tok
+                              , testCase "Query Count Items" $ queryCountItemTest tok
                               , testCase "Query Max Items" $ queryMaxItemTest tok
                               , testCase "Create Item" $ createItemTest tok
                               , testCase "Read Item" $ readItemTest tok
@@ -145,8 +147,9 @@ queryMaxItemTest oAuthToken = do
     Right (QuickBooksItemResponse (item:_)) -> do
       assertEither "Queried for max size" eitherQueryItems
 
-queryCountTest :: OAuthToken -> Assertion
-queryCountTest oAuthToken = do
+---- Query Count Item ----
+queryCountItemTest :: OAuthToken -> Assertion
+queryCountItemTest oAuthToken = do
   eitherCount <- queryItemCount oAuthToken
   case eitherCount of
     Left _ ->
@@ -281,9 +284,25 @@ queryCategoryTest oAuthToken = do
       let (Right existingId) = filterTextForQB "91"
       assertBool (show $ categoryId category) (categoryId category == (Just existingId))
 
+---- Query Max Category ----
+queryMaxCategoryTest :: OAuthToken -> Assertion
+queryMaxCategoryTest oAuthToken = do
+  eitherQueryCategories <- queryMaxCategoriesFrom oAuthToken 1
+  case eitherQueryCategories of
+    Left _ ->
+      assertEither "Failed to query category" eitherQueryCategories
+    Right (QuickBooksCategoryResponse (category:_)) -> do
+      assertEither "Queried for max size" eitherQueryCategories
 
-
-
+---- Query Count Category ----
+queryCountCategoryTest :: OAuthToken -> Assertion
+queryCountCategoryTest oAuthToken = do
+  eitherCount <- queryCategoryCount oAuthToken
+  case eitherCount of
+    Left _ ->
+      assertEither "Failed to query category count" eitherCount
+    Right (QuickBooksCountResponse size) ->
+      assertEither "Queried the count" eitherCount
 
 ---- Invoice CRUD-Email ----
 createInvoiceTest :: OAuthToken -> Assertion


### PR DESCRIPTION
Added query requests for count and max amount in items and categories.

QBText is a safe checking type for input into the quickbooks API. It functions based off of a black list and character filtering. And characters that cause the API to perform in an unexpected manner should be added to the filterTextForQB function.